### PR TITLE
Improve reset button

### DIFF
--- a/qargparse.py
+++ b/qargparse.py
@@ -140,8 +140,8 @@ class QArgumentParser(QtWidgets.QWidget):
             widget.setEnabled(arg["enabled"])
 
         # Reset btn widget
-        _reset = QtWidgets.QWidget()
-        _reset.setProperty("type", "QArgparse:reset")
+        reset_container = QtWidgets.QWidget()
+        reset_container.setProperty("type", "QArgparse:reset")
         reset = QtWidgets.QPushButton("")  # default
         reset.setToolTip("Reset")
         reset.hide()  # shown on edit
@@ -152,14 +152,14 @@ class QArgumentParser(QtWidgets.QWidget):
         alignment = (QtCore.Qt.AlignTop,) if label_on_top else ()
 
         # Layout
-        layout = QtWidgets.QVBoxLayout(_reset)
+        layout = QtWidgets.QVBoxLayout(reset_container)
         layout.addWidget(reset)
         layout.setContentsMargins(0, 0, 0, 0)
 
         layout = self.layout()
         layout.addWidget(label, self._row, 0, *alignment)
         layout.addWidget(widget, self._row, 1)
-        layout.addWidget(_reset, self._row, 2, *alignment)
+        layout.addWidget(reset_container, self._row, 2, *alignment)
         layout.setColumnStretch(1, 1)
 
         # Signals

--- a/qargparse.py
+++ b/qargparse.py
@@ -63,7 +63,7 @@ class QArgumentParser(QtWidgets.QWidget):
         self._row = 1
         self._storage = storage
         self._arguments = odict()
-        self._desciption = description
+        self._description = description
 
         for arg in arguments or []:
             self._addArgument(arg)
@@ -71,7 +71,7 @@ class QArgumentParser(QtWidgets.QWidget):
         self.setStyleSheet(style)
 
     def setDescription(self, text):
-        self._desciption.setText(text)
+        self._description.setText(text)
 
     def addArgument(self, name, type=None, default=None, **kwargs):
         # Infer type from default
@@ -145,7 +145,7 @@ class QArgumentParser(QtWidgets.QWidget):
             widget.setAttribute(QtCore.Qt.WA_StyledBackground)
             widget.setEnabled(arg["enabled"])
 
-        # Align label on top of row if widget is over two times heiger
+        # Align label on top of row if widget is over two times higher
         height = (lambda w: w.sizeHint().height())
         label_on_top = height(label) * 2 < height(widget)
         alignment = (QtCore.Qt.AlignTop,) if label_on_top else ()

--- a/qargparse.py
+++ b/qargparse.py
@@ -135,8 +135,8 @@ class QArgumentParser(QtWidgets.QWidget):
         reset.setProperty("type", "reset")
         reset.clicked.connect(lambda: self.on_reset(arg))
 
-        # Shown on edit
-        reset.hide()
+        # Enable on edit
+        reset.setEnabled(False)
 
         for widget in (label, widget):
             widget.setToolTip(arg["help"])
@@ -157,7 +157,7 @@ class QArgumentParser(QtWidgets.QWidget):
         layout.setColumnStretch(1, 1)
 
         def on_changed(*_):
-            reset.setVisible(arg["edited"])
+            reset.setEnabled(arg["edited"])
 
         arg.changed.connect(on_changed)
 

--- a/qargparse.py
+++ b/qargparse.py
@@ -726,6 +726,11 @@ QLabel[type="Separator"] {
 QPushButton[type="reset"] {
     max-width: 11px;
     max-height: 11px;
+    /* Set padding to 0 for ensuring fixed size */
+    padding-top: 0px;
+    padding-bottom: 0px;
+    padding-left: 0px;
+    padding-right: 0px;
 }
 
 """

--- a/qargparse.py
+++ b/qargparse.py
@@ -72,6 +72,7 @@ class QArgumentParser(QtWidgets.QWidget):
         self.setStyleSheet(style)
 
     def setDescription(self, text):
+        # (TODO) This won't work.
         self._description.setText(text)
 
     def addArgument(self, name, type=None, default=None, **kwargs):
@@ -783,7 +784,7 @@ def _demo():
     parser.add_argument("age", default=33, help="Your age")
     parser.add_argument("height", default=1.87, help="Your height")
     parser.add_argument("alive", default=True, help="Your state")
-    parser.add_argument("class", type=Enum, items=[
+    parser.add_argument("class", type=Enum, items=[  # (TODO) Reset not hidden
         "Ranger",
         "Warrior",
         "Sorcerer",
@@ -791,7 +792,7 @@ def _demo():
     ], default=2, help="Your class")
 
     parser.add_argument("options", type=Separator)
-    parser.add_argument("paths", type=InfoList, items=[
+    parser.add_argument("paths", type=InfoList, items=[  # (TODO) Doesn't work
         "Value A",
         "Value B",
         "Some other value",


### PR DESCRIPTION
### What's changed
* Ensure reset button size fixed when parent widget has padding setup in it's style. (Like in Avalon's style)
* Keep layout unchanged when reset button shown or hidden.
* Added a few *TODO* for future homework.

Noted that I did a signal connections refactor in commit 5103c1c which might need to be looked closer.