### PR TITLE
Fix TypeError when reading numeric value back from .ini

### DIFF
--- a/qargparse.py
+++ b/qargparse.py
@@ -122,6 +122,12 @@ class QArgumentParser(QtWidgets.QWidget):
                         "true": QtCore.Qt.Checked,
                     }.get(default))
 
+                if isinstance(arg, Number):
+                    if isinstance(arg, Float):
+                        default = float(default)
+                    else:
+                        default = int(default)
+
                 arg["default"] = default
 
         # Argument label and editor widget

--- a/qargparse.py
+++ b/qargparse.py
@@ -4,7 +4,7 @@ import logging
 from collections import OrderedDict as odict
 from Qt import QtCore, QtWidgets, QtGui
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 _log = logging.getLogger(__name__)
 _type = type  # used as argument
 


### PR DESCRIPTION
### Problem

While saving numeric value change with `QSettings`, `TypeError` raised when reading it back.

```
TypeError: 'PySide2.QtWidgets.QSpinBox.setValue' called with wrong argument types:
  PySide2.QtWidgets.QSpinBox.setValue(str)
Supported signatures:
  PySide2.QtWidgets.QSpinBox.setValue(int)
```

This PR resolved this.

*Sorry, I hit the wrong button to push directly into here, just force pushed it back and creating this one.*
