### PR TITLE
Fix Enum, QArgumentParser.setDescription and update test

### DIFF
--- a/qargparse.py
+++ b/qargparse.py
@@ -687,8 +687,8 @@ class Enum(QArgument):
         label (str, optional): Display name, convert from `name` if not given
         help (str, optional): Tool tip message of this argument
         items (list, optional): List of strings for select, default `[]`
-        default (int, optional): Index of default item, use first of `items`
-            if not given.
+        default (int, str, optional): Index or text of default item, use first
+            of `items` if not given.
         enabled (bool, optional): Whether to enable this widget, default True
 
     """
@@ -711,7 +711,16 @@ class Enum(QArgument):
         self._read = lambda: widget.currentText()
         self._write = lambda value: widget.setCurrentText(value)
 
-        if self["default"] is not None:
+        if self["default"] is not None and len(self["items"]):
+            if isinstance(self["default"], int):
+                index = self["default"]
+                index = 0 if index > len(self["items"]) else index
+                self["default"] = self["items"][index]
+            else:
+                # Must be str type. If the default str is not in list, will
+                # fallback to the first item silently.
+                pass
+
             self._write(self["default"])
 
         return widget

--- a/qargparse.py
+++ b/qargparse.py
@@ -57,8 +57,9 @@ class QArgumentParser(QtWidgets.QWidget):
         layout = QtWidgets.QGridLayout(self)
         layout.setRowStretch(999, 1)
 
-        if description:
-            layout.addWidget(QtWidgets.QLabel(description), 0, 0, 1, 2)
+        description = QtWidgets.QLabel(description or "")
+        description.setVisible(bool(False))
+        layout.addWidget(description, 0, 0, 1, 2)
 
         self._row = 1
         self._storage = storage
@@ -72,8 +73,8 @@ class QArgumentParser(QtWidgets.QWidget):
         self.setStyleSheet(style)
 
     def setDescription(self, text):
-        # (TODO) This won't work.
-        self._description.setText(text)
+        self._description.setText(text or "")
+        self._description.setVisible(bool(text))
 
     def addArgument(self, name, type=None, default=None, **kwargs):
         # Infer type from default

--- a/qargparse.py
+++ b/qargparse.py
@@ -4,7 +4,7 @@ import logging
 from collections import OrderedDict as odict
 from Qt import QtCore, QtWidgets, QtGui
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 _log = logging.getLogger(__name__)
 _type = type  # used as argument
 

--- a/qargparse.py
+++ b/qargparse.py
@@ -693,7 +693,7 @@ class Enum(QArgument):
 
     """
     def __init__(self, name, **kwargs):
-        kwargs["default"] = kwargs.pop("default", 0)
+        kwargs["default"] = kwargs.pop("default", None)
         kwargs["items"] = kwargs.get("items", [])
 
         assert isinstance(kwargs["items"], (tuple, list)), (
@@ -709,7 +709,7 @@ class Enum(QArgument):
             lambda index: self.changed.emit())
 
         self._read = lambda: widget.currentText()
-        self._write = lambda value: widget.setCurrentIndex(value)
+        self._write = lambda value: widget.setCurrentText(value)
 
         if self["default"] is not None:
             self._write(self["default"])

--- a/test.py
+++ b/test.py
@@ -64,7 +64,7 @@ with __auto__("All..") as parser:
     ], default=2, help="Your class")
 
     parser.add_argument("Options", type=qargparse.Separator)
-    parser.add_argument("paths", type=qargparse.MultiString, items=[
+    parser.add_argument("paths", type=qargparse.InfoList, items=[
         "Value A",
         "Value B",
         "Some other value",
@@ -77,13 +77,32 @@ if opts.demo:
     exit(0)
 
 
-with __auto__("MultiString..") as parser:
+with __auto__("InfoList..") as parser:
     parser.setDescription("Entering many items..")
-    parser.add_argument("paths", type=qargparse.MultiString)
+    parser.add_argument("paths", type=qargparse.InfoList, items=[
+        "Value A",
+        "Value B",
+        "Some other value",
+        "And finally, value C",
+    ])
 
 
 with __auto__("Enum..") as parser:
-    en = parser.add_argument("myOptions", default=1, items=["a", "b", "c"])
+    en = parser.add_argument("myOptions", default=1, items=["a", "b", "c"],
+                             type=qargparse.Enum)
+    assert en.read() == "b", en.read()
+
+
+with __auto__("Enum with string default..") as parser:
+    en = parser.add_argument("myOptions", default="b", items=["a", "b", "c"],
+                             type=qargparse.Enum)
+    assert en.read() == "b", en.read()
+
+
+with __auto__("Enum with fallback..") as parser:
+    en = parser.add_argument("myOptions", default=5, items=["a", "b", "c"],
+                             type=qargparse.Enum)
+    assert en.read() == "a", en.read()
 
 
 with __auto__("Defaults..") as parser:


### PR DESCRIPTION
### Problems

* `Enum.read` returns current selection as string, but `Enum.write` takes `int` index.

    This cause error when reading value back from `.ini`, change `Enum.write` to take `str` input fixed the issue.

* `test.py` outdated and fail to run

    So I update the deprecated code and fixed the `QArgumentParser.setDescription` on my way here.

*Sorry (again), I hit the wrong button to push directly into here, just force pushed it back and creating this one.*
