### PR TITLE
HDPI and no Qt.py

### DIFF
--- a/qargparse.py
+++ b/qargparse.py
@@ -16,6 +16,41 @@ except NameError:
     _basestring = str
 
 
+style = """\
+QWidget {
+    /* Explicitly specify a size, to account for automatic HDPi */
+    font-size: 8pt;
+}
+
+*[type="Button"] {
+    text-align:left;
+}
+
+*[type="Info"] {
+    background: transparent;
+    border: none;
+}
+
+QLabel[type="Separator"] {
+    min-height: 20px;
+    text-decoration: underline;
+}
+
+QWidget[type="QArgparse:reset"] {
+    /* Ensure size fixed */
+    max-width: 11px;
+    max-height: 11px;
+    min-width: 11px;
+    min-height: 11px;
+    padding-top: 0px;
+    padding-bottom: 0px;
+    padding-left: 0px;
+    padding-right: 0px;
+}
+
+"""
+
+
 class QArgumentParser(QtWidgets.QWidget):
     """User interface arguments
 
@@ -72,6 +107,12 @@ class QArgumentParser(QtWidgets.QWidget):
             self._addArgument(arg)
 
         self.setStyleSheet(style)
+
+    def _dpiScale(self):
+        """Scale used by OS for high-DPI/retina resolutions like 4K"""
+
+        # E.g. 1.5 or 2.0
+        return self.windowHandle().screen().logicalDotsPerInch() / 96.0
 
     def setDescription(self, text):
         self._description.setText(text or "")
@@ -734,41 +775,6 @@ class Enum(QArgument):
             self._write(self["default"])
 
         return widget
-
-
-style = """\
-QWidget {
-    /* Explicitly specify a size, to account for automatic HDPi */
-    font-size: 11px;
-}
-
-*[type="Button"] {
-    text-align:left;
-}
-
-*[type="Info"] {
-    background: transparent;
-    border: none;
-}
-
-QLabel[type="Separator"] {
-    min-height: 20px;
-    text-decoration: underline;
-}
-
-QWidget[type="QArgparse:reset"] {
-    /* Ensure size fixed */
-    max-width: 11px;
-    max-height: 11px;
-    min-width: 11px;
-    min-height: 11px;
-    padding-top: 0px;
-    padding-bottom: 0px;
-    padding-left: 0px;
-    padding-right: 0px;
-}
-
-"""
 
 
 def camelToTitle(text):

--- a/qargparse.py
+++ b/qargparse.py
@@ -172,11 +172,21 @@ class QArgumentParser(QtWidgets.QWidget):
         for arg in arguments or []:
             self._addArgument(arg)
 
-    def show(self):
-        super(QArgumentParser, self).show()
+    def showEvent(self, event):
+
+        # Account for showing with .show()
+        # and implicit show as child of another widget
+        super(QArgumentParser, self).showEvent(event)
 
         # There isn't a window handle until *after* the widget has been shown
-        style = scaled_style(self._dpiScale())
+        try:
+            scale = self._dpiScale()
+        except AttributeError:
+            # If for whatever reason we can't get scale at this time,
+            # that's fine, we'll just use some reasonable default
+            scale = 1.0
+
+        style = scaled_style(scale)
         self.setStyleSheet(style)
 
     def _dpiScale(self):

--- a/qargparse.py
+++ b/qargparse.py
@@ -99,6 +99,13 @@ QWidget[type="QArgparse:reset"] {
 
 
 def scaled_style(scale):
+    """Replace any mention of <num>px with scaled version
+
+    This way, you can still use px without worrying about what
+    it will look like at HDPI resolution.
+
+    """
+
     output = []
     for line in style.splitlines():
         line = line.rstrip()

--- a/qargparse.py
+++ b/qargparse.py
@@ -267,6 +267,7 @@ class Boolean(QArgument):
         enabled (bool, optional): Whether to enable this widget, default True
 
     """
+
     def create(self):
         widget = QtWidgets.QCheckBox()
         widget.clicked.connect(self.changed.emit)
@@ -448,6 +449,7 @@ class String(QArgument):
         enabled (bool, optional): Whether to enable this widget, default True
 
     """
+
     def __init__(self, *args, **kwargs):
         super(String, self).__init__(*args, **kwargs)
         self._previous = None
@@ -561,6 +563,7 @@ class InfoList(QArgument):
     Presented by `QtWidgets.QListView`, not production ready.
 
     """
+
     def __init__(self, name, **kwargs):
         kwargs["default"] = kwargs.pop("default", ["Empty"])
         super(InfoList, self).__init__(name, **kwargs)
@@ -596,6 +599,7 @@ class Choice(QArgument):
         enabled (bool, optional): Whether to enable this widget, default True
 
     """
+
     def __init__(self, name, **kwargs):
         kwargs["items"] = kwargs.get("items", ["Empty"])
         kwargs["default"] = kwargs.pop("default", kwargs["items"][0])
@@ -694,6 +698,7 @@ class Enum(QArgument):
         enabled (bool, optional): Whether to enable this widget, default True
 
     """
+
     def __init__(self, name, **kwargs):
         kwargs["default"] = kwargs.pop("default", None)
         kwargs["items"] = kwargs.get("items", [])


### PR DESCRIPTION
This would leave some elements much too small on a high-dpi screen.

| Before | After
|:--------|:----------
| ![image](https://user-images.githubusercontent.com/2152766/98368531-6bdb0680-202f-11eb-8362-54d354bac044.png) | ![image](https://user-images.githubusercontent.com/2152766/98368468-4bab4780-202f-11eb-8c72-7e92b0bb0fed.png)

At 100% and 150%

I've also removed the dependency on Qt.py, didn't seem necessary and should help with distribution. This also now requires a Qt 5 binding - PySide2 or PyQt5 - as Qt 4 is going out of style. Additionally, the HDPI mechanism only exists with Qt 5 so there's that.