### PR TITLE
Remove duplicated signal connection in `Boolean`

### DIFF
--- a/qargparse.py
+++ b/qargparse.py
@@ -5,7 +5,7 @@ import logging
 from collections import OrderedDict as odict
 from Qt import QtCore, QtWidgets, QtGui
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 _log = logging.getLogger(__name__)
 _type = type  # used as argument
 

--- a/qargparse.py
+++ b/qargparse.py
@@ -269,7 +269,6 @@ class Boolean(QArgument):
     """
     def create(self):
         widget = QtWidgets.QCheckBox()
-        widget.clicked.connect(self.changed.emit)
 
         if isinstance(self, Tristate):
             self._read = lambda: widget.checkState()


### PR DESCRIPTION
Just found out that the `Boolean` widget is triggering `changed` signal twice everytime I press it. XD
