### PR TITLE
Fix Enum tooltip

### DIFF
--- a/qargparse.py
+++ b/qargparse.py
@@ -12,7 +12,7 @@ DefaultStyle = {
 }
 
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 _log = logging.getLogger(__name__)
 _type = type  # used as argument
 _dpi = None

--- a/qargparse.py
+++ b/qargparse.py
@@ -1132,7 +1132,10 @@ class Enum(QArgument):
         return self.read() != default
 
     def compose_reset_tip(self):
-        return "Reset to %s" % self["items"][self["default"]]
+        default = self["default"]
+        if isinstance(default, int):
+            default = self["items"][default]
+        return "Reset to %s" % default
 
 
 def camelToTitle(text):


### PR DESCRIPTION
Somehow I forgot to test out Enum tool tip (from #15) that composed from previous storaged default value, which is string instead of index and leads to error.

This PR fixed that. 🤕 